### PR TITLE
clients are now initialized for each node separately

### DIFF
--- a/examples/eida_test.py
+++ b/examples/eida_test.py
@@ -85,11 +85,11 @@ def main():
     # path to personal eida token here
     token = args.authentication
 
-    eida_nodes = [ "ODC", "GFZ", "RESIF", "INGV", "ETH", "BGR", "NIEP", "KOERI", "LMU", "NOA", "UIB", "ICGC" ]
+    eida_nodes = [ "ODC", "GFZ", "RESIF", "INGV", "ETH", "BGR", "NIEP", "KOERI", "LMU", "NOA", "ICGC" ]
 
     for node in eida_nodes:
 
-        rsClient = Client(base_url=node, eida_token=token)
+        rsClient = Client(base_url=node,timeout=args.timeout)
 
         for y in range(args.start, args.end+1):
             print('Processing year %d' % y)
@@ -170,6 +170,7 @@ def main():
                                     # get the data
                                     data_temp = rsClient.get_waveforms(network=net.code,
                                                                        station=sta.code,
+                                                                       location='*',
                                                                        channel=cha.code,
                                                                        starttime=start,
                                                                        endtime=end)

--- a/examples/plot_availability.py
+++ b/examples/plot_availability.py
@@ -27,7 +27,7 @@ def main():
     years = set()
 
     for line in fin.readlines():
-        year, net, sta, cha, percavailable, minutes, wfc, inventory = line.split(' ')
+        year, net, sta, cha, percavailable, minutes, wfc, inventory , node= line.split(' ')
         year = int(year)
         percavailable = float(percavailable)
         wfc = float(wfc)


### PR DESCRIPTION
Hi, I changed the eida_test.py script to initialize the clients for each node separately, since we agreed on not using the routing client for the next round of our data availability test.

I had to remove the timeout parameter from the get_station call (l.96 in the original version), because it produced an error message stating that this parameter not supported.

I also added an eigth column to the results.txt file with the node in question.